### PR TITLE
Allow path to be buffer.

### DIFF
--- a/fvcore/common/checkpoint.py
+++ b/fvcore/common/checkpoint.py
@@ -3,6 +3,7 @@
 
 import logging
 import os
+import io
 from collections import defaultdict
 from typing import Any, Dict, Iterable, List, NamedTuple, Optional, Tuple
 
@@ -136,7 +137,7 @@ class Checkpointer:
             self.logger.info("No checkpoint found. Initializing model from scratch")
             return {}
         self.logger.info("Loading checkpoint from {}".format(path))
-        if not os.path.isfile(path):
+        if not os.path.isfile(path) and not isinstance(path, io.BytesIO):
             path = self.path_manager.get_local_path(path)
             assert os.path.isfile(path), "Checkpoint {} not found!".format(path)
 


### PR DESCRIPTION
This is to allow models to be downloaded as strings. 

See https://stackoverflow.com/questions/57898998/is-it-possible-to-load-a-pretrained-pytorch-model-from-a-gcs-bucket-url-without